### PR TITLE
Specify filename for send_file

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -70,5 +70,5 @@ function customfield_file_pluginfile($course, $cm, $context, $filearea, $args, $
     }
 
     // We can now send the file back to the browser - in this case with a cache lifetime of 1 day and no filtering.
-    send_file($file, 86400, 0, $forcedownload, $options);
+    send_file($file, $filename, 86400, 0, $forcedownload, $options);
 }


### PR DESCRIPTION
Looks like the call to `send_file`  was mixed up with [stored_file::send_file](https://github.com/moodle/moodle/blob/85afb069a016d1ca46e3c4e84d074a38e8b1fb62/lib/filestorage/stored_file.php#L1058).

`send_file` requires a filename parameter.

Fixes #5 