### PR TITLE
Fix issue #4 Use course context for file record

### DIFF
--- a/classes/data_controller.php
+++ b/classes/data_controller.php
@@ -73,7 +73,7 @@ class data_controller extends \core_customfield\data_controller {
             $this->save();
         }
 
-        $context = $this->get_field()->get_handler()->get_configuration_context();
+        $context = $this->get_context();
         file_save_draft_area_files(
             $datanew->{$fieldname},
             $context->id,
@@ -96,7 +96,7 @@ class data_controller extends \core_customfield\data_controller {
     }
 
     public function instance_form_before_set_data($data) {
-        $context = $this->get_field()->get_handler()->get_configuration_context();
+        $context = $this->get_context();
         $draftideditor = file_get_submitted_draft_itemid($this->get_form_element_name());
         file_prepare_draft_area($draftideditor, $context->id, 'customfield_file',
             'value', $this->get('id'), $this->get_filemanageroptions());
@@ -111,7 +111,7 @@ class data_controller extends \core_customfield\data_controller {
     public function export_value() {
         global $OUTPUT, $PAGE;
 
-        $context = $this->get_field()->get_handler()->get_configuration_context();
+        $context = $this->get_context();
         $fs = get_file_storage();
 
         $files = $fs->get_area_files($context->id, 'customfield_file', "value",

--- a/classes/field_controller.php
+++ b/classes/field_controller.php
@@ -68,10 +68,6 @@ class field_controller extends \core_customfield\field_controller {
         global $DB;
         $fs = get_file_storage();
 
-        // Delete files in the defaultvalue.
-        $fs->delete_area_files($this->get_handler()->get_configuration_context()->id, 'customfield_file',
-            'defaultvalue', $this->get('id'));
-
         // Delete files in the data. We can not use $fs->delete_area_files_select() because context may be different.
         $params = ['component' => 'customfield_file', 'filearea' => 'value', 'fieldid' => $this->get('id')];
         $where = "component = :component AND filearea = :filearea

--- a/classes/task/update_file_context.php
+++ b/classes/task/update_file_context.php
@@ -1,0 +1,60 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace customfield_file\task;
+
+use core\task\adhoc_task;
+
+/**
+ * Runs file context update.
+ *
+ * @package    customfield_file
+ * @author     Tomo Tsuyuki <tomotsuyuki@catalyst-au.net>
+ * @copyright  2024 Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class update_file_context extends adhoc_task {
+
+    /**
+     * Run the task.
+     *
+     * @return void
+     */
+    public function execute() {
+        global $DB;
+
+        // Collect records which have wrong contextid in the file data.
+        $sql = "SELECT mf.id mfid, mcd.contextid mcdcontextid, mf.itemid, mf.filepath, mf.filename
+                  FROM {customfield_data} mcd
+                  JOIN {customfield_field} mcf ON mcf.id = mcd.fieldid
+                  JOIN {customfield_category} mcc ON mcc.id = mcf.categoryid
+                  JOIN {files} mf ON mf.itemid = mcd.id
+                 WHERE mcc.component = 'core_course' AND mcc.area = 'course'
+                       AND mcf.type = 'file'
+                       AND mf.component = 'customfield_file' AND mf.filearea = 'value'
+                       AND mcd.contextid != mf.contextid";
+        $records = $DB->get_records_sql($sql);
+        $fs = get_file_storage();
+
+        // Update records with correct contextid and pathnamehash.
+        foreach ($records as $record) {
+            $DB->set_field('files', 'contextid', $record->mcdcontextid, ['id' => $record->mfid]);
+            $pathnamehash = $fs->get_pathname_hash($record->mcdcontextid, 'customfield_file', 'value',
+                $record->itemid, $record->filepath, $record->filename);
+            $DB->set_field('files', 'pathnamehash', $pathnamehash, ['id' => $record->mfid]);
+        }
+    }
+}

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -1,0 +1,44 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Database upgrade script
+ *
+ * @package   customfield_file
+ * @author    Tomo Tsuyuki <tomotsuyuki@catalyst-au.net>
+ * @copyright 2024 Catalyst IT
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+use core\task\manager;
+use customfield_file\task\update_file_context;
+
+/**
+ * Function to upgrade customfield database
+ *
+ * @param int $oldversion the version we are upgrading from
+ * @return bool result
+ */
+function xmldb_customfield_file_upgrade($oldversion) {
+
+    if ($oldversion < 2023121401) {
+        // Add adhoc task to update contextid in file records.
+        manager::queue_adhoc_task(new update_file_context());
+        upgrade_plugin_savepoint(true, 2023121401, 'customfield', 'file');
+    }
+
+    return true;
+}

--- a/tests/plugin_test.php
+++ b/tests/plugin_test.php
@@ -1,0 +1,95 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace customfield_file;
+
+use core_customfield_generator;
+use core_customfield_test_instance_form;
+
+/**
+ * Functional test for customfield_file
+ *
+ * @package    customfield_file
+ * @copyright  2024 Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class plugin_test extends \advanced_testcase {
+
+    /** @var stdClass[]  */
+    private $courses = [];
+    /** @var \core_customfield\category_controller */
+    private $cfcat;
+    /** @var \core_customfield\field_controller[] */
+    private $cfields;
+    /** @var \core_customfield\data_controller[] */
+    private $cfdata;
+
+    /**
+     * Tests set up.
+     */
+    public function setUp(): void {
+        $this->resetAfterTest();
+        $this->setAdminUser();
+
+        $this->cfcat = $this->get_generator()->create_category();
+        $this->cfields[1] = $this->get_generator()->create_field(
+            ['categoryid' => $this->cfcat->get('id'), 'shortname' => 'myfield1', 'type' => 'file']);
+        $this->courses[1] = $this->getDataGenerator()->create_course();
+    }
+
+    /**
+     * Get generator
+     * @return core_customfield_generator
+     */
+    protected function get_generator() : core_customfield_generator {
+        return $this->getDataGenerator()->get_plugin_generator('core_customfield');
+    }
+
+    /**
+     * Test if the context is correctly set
+     *
+     * @covers ::instance_form_save
+ */
+    public function test_context() {
+        global $DB, $USER;
+        $contextcourse1 = \context_course::instance($this->courses[1]->id);
+        $usercontext = \context_user::instance($USER->id);
+        // Create a user draft file for file customfield.
+        $fs = get_file_storage();
+        $userfilerecord = new \stdClass;
+        $userfilerecord->contextid = $usercontext->id;
+        $userfilerecord->component = 'user';
+        $userfilerecord->filearea  = 'draft';
+        $userfilerecord->itemid    = 123456;
+        $userfilerecord->filepath  = '/';
+        $userfilerecord->filename  = 'customfield.txt';
+        $userfilerecord->source    = 'test';
+        $userfile = $fs->create_file_from_string($userfilerecord, 'Test content');
+
+        $this->cfdata[1] = $this->get_generator()->add_instance_data($this->cfields[1],
+            $this->courses[1]->id, $userfile->get_itemid());
+
+        // Check customfield_data context.
+        $this->assertEquals($contextcourse1->id, $this->cfdata[1]->get('contextid'));
+        // Check file context.
+        $params = ['component' => 'customfield_file', 'filearea' => 'value', 'itemid' => $this->cfdata[1]->get('id')];
+        $where = "component = :component AND filearea = :filearea AND itemid = :itemid AND filename != '.'";
+        $files = $DB->get_records_select('files', $where, $params);
+        $this->assertCount(1, $files);
+        $file = reset($files);
+        $this->assertEquals($contextcourse1->id, $file->contextid);
+    }
+}

--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'customfield_file';
-$plugin->version = 2023121400;
+$plugin->version = 2023121401;
 $plugin->requires = 2020060900;
 $plugin->release = 2020061501;
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
Use contextid for the course, instead of `get_configuration_context()`

Need to update existing file records with new `contextid` and `pathnamehash`

Delete `defaultvalue` file part as file customfield doesn't use `defaultvalue`