### PR TITLE
issue #13: remove not existing setting from backup tests

### DIFF
--- a/tests/plugin_test.php
+++ b/tests/plugin_test.php
@@ -233,7 +233,6 @@ class plugin_test extends \advanced_testcase {
         // Configure the restore settings.
         $rc->get_plan()->get_setting('logs')->set_value(true);
         $rc->get_plan()->get_setting('users')->set_value(true);
-        $rc->get_plan()->get_setting('customfields')->set_value(true);
 
         // Execute the restore process.
         $this->assertTrue($rc->execute_precheck());


### PR DESCRIPTION
This is a fix for issue #13 

Looks like `customfields` is not a valid setting. Tests are passing without this option. 

```
root@ddfe9bd67e24:/var/www/moodle45# vendor/bin/phpunit customfield/field/file/tests/plugin_test.php
Moodle 4.5.5 (Build: 20250609), 08ef9984d2d6304f8f523699c98a839ffb43dcff
Php: 8.1.32, pgsql: 16.0 (Debian 16.0-1.pgdg120+1), OS: Linux 6.11.0-26-generic x86_64
PHPUnit 9.6.18 by Sebastian Bergmann and contributors.

..                                                                  2 / 2 (100%)

Time: 00:01.369, Memory: 121.00 MB

OK (2 tests, 11 assertions)
```
